### PR TITLE
add skip-cleanup to dpl cmd to deploy current state instead of last commit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,6 @@ production:
         - echo "API_SECRET=$API_SECRET" >> .env
         - echo "PHONE_NUMBER=$PHONE_NUMBER" >> .env
         - echo "sengrid_api=$sengrid_api" >> .env
-        - dpl --provider=heroku --app=$HEROKU_APP_PRODUCTION --api-key=$HEROKU_API_KEY
+        - dpl --provider=heroku --app=$HEROKU_APP_PRODUCTION --api-key=$HEROKU_API_KEY --skip_cleanup
     only:
         - master


### PR DESCRIPTION
Let's give this a shot. The documentation for dpl says:

> Dpl will deploy by default from the latest commit. Use the --skip_cleanup flag to deploy from the current file state. Note that many providers deploy by git and could ignore this option.

https://github.com/travis-ci/dpl/blob/v1/README.md#global-flags

It may be the reason that the .env file, which is built during the pipeline, isn't being deployed to heroku.